### PR TITLE
Adding the orbital targeting system

### DIFF
--- a/OrbitalTargeting/Program.cs
+++ b/OrbitalTargeting/Program.cs
@@ -387,7 +387,11 @@ namespace IngameScript
                     log("No targetting data text panel detected. ");
                     return;
                 }
-                string text = _textPanelsTargetting.GetText();
+                foreach (IMyTextPanel panel in _textPanelsTargetting)
+                {
+                    string text = panel.GetText();
+                    t.Add(text);
+                }
                 t.Add(text);
                 if (t.calculateAverageTarget())
                 {


### PR DESCRIPTION
Adding the orbital targeting system and interfacing to the rest of te code.

The data should be contained in the text panel named "CruiseTargettingData"
It is a series of lines of GPS position followed by a distance in km. 
Spurious white space characters are ignored. 

Example : 
#1:1087630:131373:1650670:#000000:19.90
#2:1111172:130967:1631037:#000000:20.10
#3:1101042:131107:1648341:#000000:19.94
#4:1105568:145568:1631072:#000000:20.50
#5:1112285:131146:1652285:#000000:30.00
#6:1091072:131072:1648572:#000000:17.50
#7:1109451:134313:1620297:#000000:21.55

The target is calculated by this script when launching with action "calculate_target"

Signed-off-by: Samuel Albert <samuel_albert38@hotmail.com>